### PR TITLE
Supervisor and python-proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,22 @@ FROM alpine:edge
 RUN apk add --no-cache \
     --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
     openconnect \
-    && apk add --no-cache openvpn openssh
+    && apk add --no-cache openvpn openssh \
+    && apk add --no-cache py3-pip \
+    && pip --no-cache-dir install pproxy supervisor
 
 # create the root user's .ssh directory
-# modify the ssh server config to allow desired features
-# unlock the root account (TODO generate a random root password)
-# and finally generate host keys
+# unlock the root account
 RUN mkdir /root/.ssh \
     && chmod 0700 /root/.ssh \
-    && sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config \
-    && sed -i 's/^AllowTcpForwarding no/AllowTcpForwarding yes/' /etc/ssh/sshd_config \
-    && sed -i 's/^GatewayPorts no/GatewayPorts clientspecified/' /etc/ssh/sshd_config \
-    && sed -i 's/^root:!::0:::::/root:::0:::::/' /etc/shadow \
-    && ssh-keygen -A
-# Note we generate SSH keys in the image to avoid getting conflicts every time we start
-# a new container. But this means you have to rebuild the image to get unique host keys.
+    && sed -i 's/^root:!::0:::::/root:::0:::::/' /etc/shadow 
 
 COPY docker-entrypoint.sh /
+COPY etc/ssh/sshd_config /etc/ssh/
+COPY etc/supervisord.conf /etc/
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
+VOLUME /etc/ssh/
 EXPOSE 22
+EXPOSE 1080

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,11 +20,12 @@ chmod 600 /root/.ssh/authorized_keys
 
 # echo "Generating new host keys as necessary..."
 # ssh-keygen -A
+echo "Generating new host keys as necessary..."
+ssh-keygen -A
 
-echo "Starting the ssh daemon..."
-# add -D -e to start in interactive mode with debugging output
-/usr/sbin/sshd
+echo "Starting supervisor..."
+/usr/bin/supervisord --configuration=/etc/supervisord.conf --logfile=/dev/null
 
-# Execute the CMD from the Dockerfile:
+# Execute the command passed to docker (likely a VPN connection command)
 exec "$@"
 

--- a/etc/ssh/sshd_config
+++ b/etc/ssh/sshd_config
@@ -1,0 +1,117 @@
+#       $OpenBSD: sshd_config,v 1.103 2018/04/09 20:41:22 tj Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/bin:/usr/bin:/sbin:/usr/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile      .ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication no
+#PermitEmptyPasswords no
+
+# Change to no to disable s/key passwords
+#ChallengeResponseAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+#UsePAM no
+
+#AllowAgentForwarding yes
+# Feel free to re-enable these if your use case requires them.
+AllowTcpForwarding yes
+GatewayPorts clientspecified
+X11Forwarding no
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /run/sshd.pid
+#MaxStartups 10:30:100
+PermitTunnel yes
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# override default of no subsystems
+Subsystem       sftp    /usr/lib/ssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#       X11Forwarding no
+#       AllowTcpForwarding no
+#       PermitTTY no
+#       ForceCommand cvs server

--- a/etc/supervisord.conf
+++ b/etc/supervisord.conf
@@ -1,0 +1,25 @@
+[unix_http_server]
+file=/run/supervisor.sock
+
+[supervisord]
+pidfile=/run/supervisord.pid
+
+; The rpcinterface:supervisor section must remain in the config file for
+; RPC (supervisorctl/web interface) to work.  Additional interfaces may be
+; added by defining them in separate [rpcinterface:x] sections.
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+; The supervisorctl section configures how supervisorctl will connect to
+; supervisord.  configure it match the settings in either the unix_http_server
+; or inet_http_server section.
+
+[supervisorctl]
+serverurl=unix:///run/supervisor.sock
+
+[program:pproxy]
+command=/usr/bin/pproxy -l socks5://:1080
+
+[program:sshd]
+command=/usr/sbin/sshd -De


### PR DESCRIPTION
- Make a SOCKS proxy available by default (with room to expand to other types in the future)
- Use Supervisord to manage background processes
- Use a custom sshd_config file rather than editing the default one
- Generate ssh host keys on container start rather than image build to allow sharing a pre-built image