### PR TITLE
Adding quotes around $@

### DIFF
--- a/vpn.sh
+++ b/vpn.sh
@@ -51,7 +51,7 @@ openvpn() {
     dockerCmd+=("$dockerImage")
 
     # append any extra args provided
-    vpnCmd+=($@)
+    vpnCmd+=("$@")
     # display help if there are no arguments at this point
     if [ ${#vpnCmd[@]} -eq 1 ]; then
         vpnCmd+=("--help")
@@ -115,7 +115,7 @@ openconnect() {
     dockerCmd+=("$dockerImage")
 
     # append any extra args provided
-    vpnCmd+=($@)
+    vpnCmd+=("$@")
     # display help if there are no arguments at this point
     if [ ${#vpnCmd[@]} -eq 1 ]; then
         vpnCmd+=("--help")


### PR DESCRIPTION
These are needed in bash to expand the array $@
correctly, where quotes spaces are not used to break.

For instance, if you pass `--a="b c"`,
`"$@"` will correctly consider `--a="b c"` as an argument,
while `$@` will split it as `--a=b` and `c`, incorrectly.

This was e.g. required in my usecase, because I need to specify
`--authgroup='XXX YYY'` where the string `XXX YYY` is decided
by the server and contains spaces.