### PR TITLE
install supervisor and pproxy via apk to use latest alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apk add --no-cache \
     && apk add --no-cache openvpn openssh \
     && apk add --no-cache py3-pip \
     && apk add --no-cache bind-tools curl \
-    && pip --no-cache-dir install pproxy supervisor
+    && apk add --no-cache supervisor \
+    && apk add --no-cache py3-pproxy \
 
 # Fix Cannot open "/proc/sys/net/ipv4/route/flush": Read-only file system
 # See https://serverfault.com/questions/878443/when-running-vpnc-in-docker-get-cannot-open-proc-sys-net-ipv4-route-flush 


### PR DESCRIPTION
Just move the python package installation from pip to apk, because system wide package installation is not allowed via pip anymore with new alpine images.